### PR TITLE
Correct Dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     directory: /
     schedule:
       interval: daily
-      time: 14:00
+      time: '14:00'
       timezone: America/Chicago
     labels:
       - dependencies


### PR DESCRIPTION
Fix error:

"The property '#/updates/0/schedule/time' of type integer did not match the following type: string"